### PR TITLE
Remove the 2N+1 query problem on the home and profile pages

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -3,12 +3,13 @@ from articles.models import Article, Tag
 from django.contrib.auth import login as auth_login, authenticate
 from django.http import HttpResponseRedirect
 from django.contrib.auth.views import LoginView as AuthLoginView
-from django.shortcuts import render, redirect
+from django.shortcuts import redirect
+from django.db.models import Count
 from .forms import UserCreationForm, UserLoginForm
 
 
 def index(request):
-    articles = Article.objects.all()
+    articles = Article.objects.all().select_related("author__user").annotate(favorited_by__count=Count("favorited_by"))
     tags = Tag.objects.all()
     return render(request, "index.html", context={"articles": articles, "tags": tags})
 

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -1,14 +1,14 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from .forms import EditProfileForm
-from .models import Profile
+from django.db.models import Count
 from articles.models import Article
 from django.contrib.auth import get_user_model
 
 
 def view(req, profile):
     user = get_object_or_404(get_user_model(), username=profile)
-    articles = Article.objects.filter(author=user.profile)
+    articles = Article.objects.filter(author=user.profile).select_related("author").annotate(favorited_by__count=Count("favorited_by"))
     return render(
         req, "profile/detail.html", context={"article_user": user, "articles": articles}
     )

--- a/templates/articles/list.html
+++ b/templates/articles/list.html
@@ -14,7 +14,7 @@
       <span class="date">{{ article.created_at }}</span>
     </div>
     <button class="btn btn-outline-primary btn-sm pull-xs-right">
-      <i class="ion-heart"></i> {{ article.favorited_by.count }}
+      <i class="ion-heart"></i> {{ article.favorited_by__count }}
     </button>
   </div>
   <a href="{% url 'article_view' article.slug %}" class="preview-link">


### PR DESCRIPTION
This reduces the query count of the homepage (after a `./manage.py createdata 100`) from ~750 to 2.