### PR TITLE
#8 - Allow users to favorite articles

### DIFF
--- a/realworld/urls.py
+++ b/realworld/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("", home_views.index, name="index"),
     path("article/<slug:slug>/", articles_views.view, name="article_view"),
+    path("article/<slug:slug>/favorite/", articles_views.FavoriteArticle.as_view(), name="article_favorite"),
     path("editor/<slug:slug>/", articles_views.EditArticle.as_view(), name="article_edit"),
     path("editor/", articles_views.CreateArticle.as_view(), name="article_create"),
     path("@<slug:profile>/", profile_views.view, name="profile_view"),

--- a/templates/articles/_favorite.html
+++ b/templates/articles/_favorite.html
@@ -1,0 +1,24 @@
+<turbo-frame id="favorite-button-{{ article.slug }}">
+  {% if request.user.is_authenticated %}
+    <form method="POST" action="{% url 'article_favorite' article.slug %}" class="list-inline-item">
+      {% csrf_token %}
+
+      {% if has_favorited %}
+        <button class="btn btn-sm btn-primary">
+          <i class="ion-heart"></i>
+          &nbsp; Unfavorite Post <span class="counter">({{ article.favorited_by__count }})</span>
+        </button>
+      {% else %}
+        <button class="btn btn-sm btn-outline-primary">
+          <i class="ion-heart"></i>
+          &nbsp; Favorite Post <span class="counter">({{ article.favorited_by__count }})</span>
+        </button>
+      {% endif %}
+    </form>
+  {% else %}
+    <a data-turbo="false" href="{% url 'login' %}" class="btn btn-sm btn-outline-primary">
+      <i class="ion-heart"></i>
+      &nbsp; Login to Favorite <span class="counter">({{ article.favorited_by__count }})</span>
+    </a>
+  {% endif %}
+</turbo-frame>

--- a/templates/articles/detail.html
+++ b/templates/articles/detail.html
@@ -15,10 +15,11 @@
           &nbsp; Follow Eric Simons <span class="counter">(10)</span>
         </button>
         &nbsp;&nbsp;
-        <button class="btn btn-sm btn-outline-primary">
-          <i class="ion-heart"></i>
-          &nbsp; Favorite Post <span class="counter">(29)</span>
-        </button>
+
+        <turbo-frame
+          id="favorite-button-{{ article.slug }}"
+          src="{% url 'article_favorite' article.slug %}"
+        />
       </div>
     </div>
   </div>
@@ -50,10 +51,10 @@
           &nbsp; Follow Eric Simons <span class="counter">(10)</span>
         </button>
         &nbsp;
-        <button class="btn btn-sm btn-outline-primary">
-          <i class="ion-heart"></i>
-          &nbsp; Favorite Post <span class="counter">(29)</span>
-        </button>
+        <turbo-frame
+          id="favorite-button-{{ article.slug }}"
+          src="{% url 'article_favorite' article.slug %}"
+        />
       </div>
     </div>
 

--- a/templates/articles/list.html
+++ b/templates/articles/list.html
@@ -13,9 +13,13 @@
       </a>
       <span class="date">{{ article.created_at }}</span>
     </div>
-    <button class="btn btn-outline-primary btn-sm pull-xs-right">
-      <i class="ion-heart"></i> {{ article.favorited_by__count }}
-    </button>
+
+    <div class="pull-xs-right">
+      <turbo-frame
+        id="favorite-button-{{ article.slug }}"
+        src="{% url 'article_favorite' article.slug %}"
+      />
+    </div>
   </div>
   <a href="{% url 'article_view' article.slug %}" class="preview-link">
     <h1>{{ article.title }}</h1>


### PR DESCRIPTION
Note:
I don't know why yet, but the turbo-frames are not being updated with eachother. When I favorite a article, only the first turbo-frame gets updated, which make sense but I couldn't find anything on the docs to make both turbo-frames work.

![Screen Shot 2021-01-08 at 19 21 13](https://user-images.githubusercontent.com/1490875/104071023-fb936180-51e6-11eb-9e7c-b23534b5ea03.png)

Context: #8 

Description:
- Added a new template/turbo-frame called `_favorite.html`
- Create a new view called `FavoriteArticle` to handle favorite/unfavorite articles with annotated `favorited_by__count`

Screenshots:
![Screen Shot 2021-01-08 at 19 24 27](https://user-images.githubusercontent.com/1490875/104071111-35646800-51e7-11eb-8b62-68296b1dff57.png)
![Screen Shot 2021-01-08 at 19 24 33](https://user-images.githubusercontent.com/1490875/104071114-36959500-51e7-11eb-83bb-68f3f200456e.png)
![Screen Shot 2021-01-08 at 19 24 44](https://user-images.githubusercontent.com/1490875/104071115-372e2b80-51e7-11eb-8b11-ee808119a372.png)
